### PR TITLE
Use Date in string format,and prevent error

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -10,6 +10,12 @@
  * @returns {Boolean} `true` if the date is invalid, `false` otherwise.
  */
 module.exports = function dateIsInvalid (d) {
+    // prevent error message in case of an invalid entry
+    try {
+        d.getTime();
+    } catch (error) {
+        d = new Date(d);
+    }
     let t = d.getTime();
     return t !== t;
 };

--- a/package.json
+++ b/package.json
@@ -18,6 +18,9 @@
     "test": "node test"
   },
   "author": "Ionică Bizău <bizauionica@gmail.com> (https://ionicabizau.net)",
+  "contributors": [
+    "Desiderio Silva <desideriotbs@gmail.com> (https://github.com/dsilva01)"
+ ],
   "repository": {
     "type": "git",
     "url": "git+ssh://git@github.com/IonicaBizau/date-is-invalid.git"


### PR DESCRIPTION
## Support to Date in string format,and prevent error
### E.g fix
> > > > > ```js
> > > > > const dateIsInvalid = require("data-is-invalid")
> > > > > 
> > > > > console.log(dateIsInvalid("1980-10-06")); 
> > > > > 
> > > > > console.log(dateIsInvalid("dfs"));
> > > > > ```
> > > > > 
> > > > > 
> > > > >     
> > > > >       
> > > > >     
> > > > > 
> > > > >       
> > > > >     
> > > > > 
> > > > >     
> > > > >   
> > > > > The expected output is `false`, as `1980-10-06` is a date. It logs `Error` instead.
> > > > > The expected output is `true`, as `dfs` is a string. It logs `Error` instead.

